### PR TITLE
fix(snap): ros-humble-dataspeed-dbw-msgs got removed

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,7 +78,6 @@ parts:
       - ros-humble-control-msgs
       - ros-humble-controller-manager-msgs
       - ros-humble-create-msgs
-      - ros-humble-dataspeed-dbw-msgs
       - ros-humble-dataspeed-ulc-msgs
       - ros-humble-dbw-fca-msgs
       - ros-humble-dbw-ford-msgs


### PR DESCRIPTION
package ros-humble-dataspeed-dbw-msgs got removed


https://discourse.ros.org/t/new-packages-and-patch-release-for-humble-hawksbill-2024-05-23/37872#removed-packages-4-4